### PR TITLE
fix and organize translations

### DIFF
--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -11,6 +11,7 @@ return [
         "submit" => [
             "label" => "Sign up",
         ],
+        "notification_unique" => "An account with this email already exists. Please login."
     ],
     "reset_password" => [
         "title" => "Forgot password",
@@ -18,6 +19,7 @@ return [
         "submit" => [
             "label" => "Submit",
         ],
+        "notification_error" => "Error: please try again later.",
         "notification_success" => "Check your inbox for instructions!",
     ],
     "verification" => [
@@ -27,6 +29,7 @@ return [
             "label" => "Sign out",
         ],
         "notification_success" => "Check your inbox for instructions!",
+        "notification_resend" => "Verification email has been resent.",
         "before_proceeding" => "Before proceeding, please check your email for a verification link.",
         "not_receive" => "If you did not receive the email,",
         "request_another" => "click here to request another one.",
@@ -38,10 +41,6 @@ return [
             "submit" => [
                 "label" => "Update",
             ],
-            "fields" => [
-                "name" => "Name",
-                "email" => "Email",
-            ],
             "notify" => "Profile updated successfully!",
         ],
         "password" => [
@@ -50,13 +49,16 @@ return [
             "submit" => [
                 "label" => "Update",
             ],
-            "fields" => [
-
-                "new_password" => "New password",
-                "new_password_confirmation" => "Confirm passord",
-            ],
             "notify" => "Password updated successfully!",
         ],
     ],
-    "or" => "Or"
+    "fields" => [
+        "name" => "Name",
+        "email" => "Email",
+        "password" => "Password",
+        "password_confirm" => "Password confirm",
+        "new_password" => "New password",
+        "new_password_confirmation" => "Confirm password",
+    ],
+    "or" => "Or",
 ];

--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -2,7 +2,8 @@
 
 return [
     "login" => [
-        "forgot_password_link" => "Mot de passe oublié?",
+        "forgot_password_link" => "Mot de passe oublié ?",
+        "create_an_account" => "Créer un compte",
     ],
     "registration" => [
         "title" => "S'inscrire",
@@ -10,37 +11,54 @@ return [
         "submit" => [
             "label" => "S'inscrire",
         ],
+        "notification_unique" => "Un compte avec cet email existe déjà. Veuillez vous connecter."
     ],
     "reset_password" => [
         "title" => "Mot de passe oublié",
         "heading" => "Réinitialisez votre mot de passe",
         "submit" => [
-            "label" => "Envoyer un e-mail de réinitialisation",
+            "label" => "Valider",
         ],
-        "notification_success" => "Vérifier votre e-mail!",
+        "notification_error" => "Erreur : veuillez réessayer plus tard.",
+        "notification_success" => "Vérifiez votre boîte de réception pour les instructions !",
     ],
     "verification" => [
-        "title" => "Vérifier votre e-mail",
+        "title" => "Vérifier les courriels",
         "heading" => "Vérification de l'e-mail requise",
         "submit" => [
             "label" => "Déconnexion",
         ],
-        "notification_success" => "Vérifier votre e-mail!",
+        "notification_success" => "Vérifiez votre boîte de réception pour les instructions !",
+        "notification_resend" => "L'e-mail de vérification a été renvoyé.",
+        "before_proceeding" => "Avant de continuer, veuillez vérifier votre e-mail pour un lien de vérification.",
+        "not_receive" => "Si vous n'avez pas reçu l'e-mail,",
+        "request_another" => "Cliquez ici pour en demander un autre.",
     ],
     "profile" => [
         "personal_info" => [
-            "heading" => "Personal Information",
-            "subheading" => "Manage your personal information.",
+            "heading" => "Informations personnelles",
+            "subheading" => "Gérer vos informations personnelles.",
             "submit" => [
-                "label" => "Update",
+                "label" => "Mettre à jour",
             ],
+            "notify" => "Mise à jour du profil réussie !",
         ],
         "password" => [
             "heading" => "Mot de passe",
-            "subheading" => "Must be 8 characters.",
+            "subheading" => "Doit être de 8 caractères.",
             "submit" => [
-                "label" => "Update",
+                "label" => "Mettre à jour",
             ],
+            "notify" => "Mot de passe mis à jour avec succès !",
         ],
     ],
+    "fields" => [
+        "name" => "Nom",
+        "email" => "E-mail",
+        "password" => "Mot de passe",
+        "password_confirm" => "Confirmer le mot de passe",
+        "new_password" => "Nouveau mot de passe",
+        "new_password_confirmation" => "Confirmez le mot de passe",
+    ],
+    "or" => "Ou",
 ];

--- a/resources/lang/pt_BR/default.php
+++ b/resources/lang/pt_BR/default.php
@@ -11,6 +11,7 @@ return [
         "submit" => [
             "label" => "Inscrever-se",
         ],
+        "notification_unique" => "An account with this email already exists. Please login."
     ],
     "reset_password" => [
         "title" => "Esqueceu a senha",
@@ -18,6 +19,7 @@ return [
         "submit" => [
             "label" => "Enviar",
         ],
+        "notification_error" => "Erro: Por favor, tente novamente mais tarde.",
         "notification_success" => "Verifique sua caixa de entrada para instruções!",
     ],
     "verification" => [
@@ -27,9 +29,10 @@ return [
             "label" => "Sair",
         ],
         "notification_success" => "Verifique sua caixa de entrada para instruções!",
+        "notification_resend" => "O e-mail de verificação foi reenviado.",
         "before_proceeding" => "Antes de prosseguir, por favor, verifique no seu e-mail o link de verificação.",
         "not_receive" => "Se você não recebeu o e-mail,",
-        "request_another" => "clique aqui para solicitar outro.",
+        "request_another" => "clique aqui para solicitar reenvio.",
     ],
     "profile" => [
         "personal_info" => [
@@ -37,10 +40,6 @@ return [
             "subheading" => "Gerencie suas informações pessoais.",
             "submit" => [
                 "label" => "Atualizar",
-            ],
-            "fields" => [
-                "name" => "Nome",
-                "email" => "E-mail",
             ],
             "notify" => "Perfil atualizado com sucesso!",
         ],
@@ -50,13 +49,16 @@ return [
             "submit" => [
                 "label" => "Atualizar",
             ],
-            "fields" => [
-
-                "new_password" => "Nova senha",
-                "new_password_confirmation" => "Confirme a senha",
-            ],
             "notify" => "Senha alterada com sucesso!"
         ],
+    ],
+    "fields" => [
+        "name" => "Nome",
+        "email" => "E-mail",
+        "password" => "Senha",
+        "password_confirm" => "Confirme a senha",
+        "new_password" => "Nova senha",
+        "new_password_confirmation" => "Confirme a senha",
     ],
     "or" => "Ou"
 ];

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -10,7 +10,7 @@
         </h2>
         @if(config("filament-breezy.enable_registration"))
         <p class="mt-2 text-sm text-center">
-            {{ __('filament-breezy:default.or') }}
+            {{ __('filament-breezy::default.or') }}
             <a class="text-primary-600" href="{{route('register')}}">
                 {{ strtolower(__('filament-breezy::default.registration.heading')) }}
             </a>

--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -16,7 +16,7 @@ class Login extends FilamentLogin
         if (request()->query("reset")) {
             session()->flash("notify", [
                 "status" => "success",
-                "message" => "Your password has been reset!",
+                "message" => __("passwords.reset"),
             ]);
         }
     }

--- a/src/Http/Livewire/Auth/Register.php
+++ b/src/Http/Livewire/Auth/Register.php
@@ -18,29 +18,36 @@ class Register extends Component implements Forms\Contracts\HasForms
     public $password;
     public $password_confirm;
 
-    protected $messages = [
-        "email.unique" =>
-            "An account with this email already exists. Please login.",
-    ];
-
     public function mount(): void
     {
         //
     }
 
+    public function messages(): array
+    {
+        return [
+            'email.unique' => __("filament-breezy::default.registration.notification_unique"),
+        ];
+    }
+
     protected function getFormSchema(): array
     {
         return [
-            Forms\Components\TextInput::make("name")->required(),
+            Forms\Components\TextInput::make("name")
+                ->label(__("filament-breezy.fields.name"))
+                ->required(),
             Forms\Components\TextInput::make("email")
+                ->label(__("filament-breezy.fields.email"))
                 ->required()
                 ->email()
                 ->unique(table: config('filament-breezy.user_model')),
             Forms\Components\TextInput::make("password")
+                ->label(__("filament-breezy.fields.password"))
                 ->required()
                 ->password()
                 ->rules(config('filament-breezy.password_rules')),
             Forms\Components\TextInput::make("password_confirm")
+                ->label(__("filament-breezy.fields.password_confirm"))
                 ->required()
                 ->password()
                 ->same("password"),

--- a/src/Http/Livewire/Auth/ResetPassword.php
+++ b/src/Http/Livewire/Auth/ResetPassword.php
@@ -47,6 +47,7 @@ class ResetPassword extends Component implements Forms\Contracts\HasForms
         } else {
             return [
                 Forms\Components\TextInput::make("email")
+                    ->label(__("filament-breezy.fields.email"))
                     ->required()
                     ->email()
                     ->exists(table: config('filament-breezy.user_model')),
@@ -75,7 +76,7 @@ class ResetPassword extends Component implements Forms\Contracts\HasForms
             } else {
                 session()->flash("notify", [
                     "status" => "danger",
-                    "message" => "Error: please try again later.",
+                    "message" => __("filament-breezy::default.reset_password.notification_error"),
                 ]);
             }
         } else {
@@ -83,15 +84,15 @@ class ResetPassword extends Component implements Forms\Contracts\HasForms
             if ($response == Password::RESET_LINK_SENT) {
                 session()->flash("notify", [
                     "status" => "success",
-                    "message" => "Check your inbox for instructions.",
+                    "message" => __("filament-breezy::default.reset_password.notification_success"),
                 ]);
                 $this->hasBeenSent = true;
             } else {
                 session()->flash("notify", [
                     "status" => "danger",
                     "message" => match ($response) {
-                        "passwords.throttled" => "Please wait before trying again.",
-                        "passwords.user" => "User with this email not found."
+                        "passwords.throttled" => __("passwords.throttled"),
+                        "passwords.user" => __("passwords.user")
                     },
                 ]);
             }

--- a/src/Http/Livewire/Auth/Verify.php
+++ b/src/Http/Livewire/Auth/Verify.php
@@ -41,7 +41,7 @@ class Verify extends Component implements Forms\Contracts\HasForms
 
         session()->flash("notify", [
             "status" => "success",
-            "message" => "Verification email has been resent.",
+            "message" => __("filament-breezy::default.verification.notification_resend"),
         ]);
     }
 

--- a/src/Pages/MyProfile.php
+++ b/src/Pages/MyProfile.php
@@ -42,9 +42,9 @@ class MyProfile extends Page implements Forms\Contracts\HasForms
     {
         return [
             Forms\Components\TextInput::make("name")
-                ->label(__('filament-breezy::default.profile.personal_info.fields.name')),
+                ->label(__('filament-breezy::default.fields.name')),
             Forms\Components\TextInput::make("email")->unique(ignorable: $this->user)
-                ->label(__('filament-breezy::default.profile.personal_info.fields.email')),
+                ->label(__('filament-breezy::default.fields.email')),
         ];
     }
 


### PR DESCRIPTION
Organize fields into a group;
Correct some typo into pt_br translation;
Fix: login.blade - miss ":" at line 13; (sorry)
I tried to get default Laravel translation when it exists, eg, Login.php at line 19 and ResetPassword at lines 94 and 95;

If you want changes or have suggestions, I'm at your disposal.

Thank you.