### PR TITLE
Make all component strings translatable

### DIFF
--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -32,6 +32,9 @@ return [
         "request_another" => "click here to request another one.",
     ],
     "profile" => [
+        "account" => "Account",
+        "profile" => "Profile",
+        "my_profile" => "My Profile",
         "personal_info" => [
             "heading" => "Personal Information",
             "subheading" => "Manage your personal information.",

--- a/src/Pages/MyProfile.php
+++ b/src/Pages/MyProfile.php
@@ -11,7 +11,6 @@ class MyProfile extends Page implements Forms\Contracts\HasForms
 {
     use Forms\Concerns\InteractsWithForms;
 
-    protected static ?string $navigationGroup = "Account"; //config
     protected static ?string $navigationIcon = "heroicon-o-document-text"; //config
     protected static string $view = "filament-breezy::filament.pages.my-profile";
 
@@ -85,7 +84,22 @@ class MyProfile extends Page implements Forms\Contracts\HasForms
     protected function getBreadcrumbs(): array
     {
         return [
-            url()->current() => 'Profile',
+            url()->current() => __('filament-breezy::default.profile.profile'),
         ];
+    }
+
+    protected static function getNavigationGroup(): ?string
+    {
+        return __('filament-breezy::default.profile.account');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('filament-breezy::default.profile.profile');
+    }
+
+    protected function getTitle(): string
+    {
+        return __('filament-breezy::default.profile.my_profile');
     }
 }


### PR DESCRIPTION
This PR allows all page title, navigation and breadcrumb to be translatable.