### PR TITLE
Removed extraneous full-stop from verify.blade.php

### DIFF
--- a/resources/views/verify.blade.php
+++ b/resources/views/verify.blade.php
@@ -13,7 +13,7 @@
                 {{ __('filament-breezy::default.verification.not_receive') }}
                 <a class="text-primary-600" href="#" wire:click="resend">
                     {{ __('filament-breezy::default.verification.request_another') }}
-                </a>.
+                </a>
             @else
                 <span class="block text-success-600 font-semibold">{{ __('filament-breezy::default.verification.notification_success') }}</span>
             @endunless


### PR DESCRIPTION
A full-stop was included in both the template, and the localized strings. Removed the one from the template.