### PR TITLE
Add config override for profile page in navbar

### DIFF
--- a/config/filament-breezy.php
+++ b/config/filament-breezy.php
@@ -9,6 +9,10 @@ return [
     */
     "enable_profile_page" => true,
     /*
+    | Whether or not to automatically display the My Profile page in the navigation of Filament.
+    */
+    "show_profile_page_in_navbar" => true,
+    /*
     | Set an array that's compatible with the Filament Forms rules() method. You can also pass an instance of \Illuminate\Validation\Rules\Password::class. ex.\Illuminate\Validation\Rules\Password::min(8). Rules for required and confirmed are already set. These rules will apply to the My Profile, registration, and password reset forms.
     */
     "password_rules" => ['min:8'],

--- a/src/Pages/MyProfile.php
+++ b/src/Pages/MyProfile.php
@@ -134,4 +134,9 @@ class MyProfile extends Page
     {
         return __('filament-breezy::default.profile.my_profile');
     }
+
+    protected static function shouldRegisterNavigation(): bool
+    {
+        return config('filament-breezy.show_profile_page_in_navbar');
+    }
 }


### PR DESCRIPTION
This adds the config option of `show_profile_page_in_navbar` to allow the ability to disable the navbar entry. The main use case for this is if you want to override the filament views and provide a custom link to the profile page, without relying on the sidebar. For example, using the user dropdown.

I know the current functionality exists to override it, but this provides a more convenient option to hide it from the navbar without going through the process of overriding.