### PR TITLE
Return the user's ID

### DIFF
--- a/src/Http/Livewire/BreezySanctumTokens.php
+++ b/src/Http/Livewire/BreezySanctumTokens.php
@@ -22,7 +22,7 @@ class BreezySanctumTokens extends Component implements Tables\Contracts\HasTable
 
     protected function getTableQuery(): Builder
     {
-        return PersonalAccessToken::where("tokenable_id", auth()->user()->id);
+        return PersonalAccessToken::where("tokenable_id", auth()->id());
     }
 
     protected function getTableColumns(): array


### PR DESCRIPTION
This PR proposes utilizing `->id()` shorthand to return the user's ID instead of accessing the user model and returning the ID.