### PR TITLE
fix: switch so statePath on Profile page

### DIFF
--- a/src/Pages/MyProfile.php
+++ b/src/Pages/MyProfile.php
@@ -13,6 +13,7 @@ class MyProfile extends Page
     protected static string $view = "filament-breezy::filament.pages.my-profile";
 
     public User $user;
+    public $userData;
     public $new_password;
     public $new_password_confirmation;
     public $token_name;
@@ -31,7 +32,7 @@ class MyProfile extends Page
         return array_merge(parent::getForms(), [
             "updateProfileForm" => $this->makeForm()
                 ->schema($this->getUpdateProfileFormSchema())
-                ->model($this->user),
+                ->statePath('userData'),
             "updatePasswordForm" => $this->makeForm()->schema(
                 $this->getUpdatePasswordFormSchema()
             ),


### PR DESCRIPTION
Allow to extend the MyProfile page and add additional forms that may have the 'name' column. ie. Team.name