### PR TITLE
fix: dark mode on auth-card form

### DIFF
--- a/resources/views/components/auth-card.blade.php
+++ b/resources/views/components/auth-card.blade.php
@@ -4,7 +4,7 @@
     <x-filament::notification-manager />
 
     <div class="p-2 max-w-{{config('filament-breezy.auth_card_max_w')??'md'}} space-y-8 w-screen">
-        <form wire:submit.prevent="{{$action}}" class="bg-white space-y-8 shadow border border-gray-300 dark:bg-gray-800 dark:border-gray-700 rounded-2xl p-8">
+        <form wire:submit.prevent="{{$action}}" @class(['p-8 space-y-8 bg-white border border-gray-300 shadow rounded-2xl', 'dark:bg-gray-800 dark:border-gray-700' => config('filament.dark_mode')])>
             {{$slot}}
         </form>
         <x-filament::footer />


### PR DESCRIPTION
Only apply dark mode on the form if filament.dark_mode is true.