### PR TITLE
Bugfix: Attempt to read property "has_confirmed_two_factor"

### DIFF
--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -86,7 +86,7 @@ class Login extends FilamentLogin
                 $this->user = $model::where($this->loginColumn, $data[$this->fieldType])->first();
 
                 // If the user hasn't setup 2FA, authenticate and exit early.
-                if (! $this->user->has_confirmed_two_factor) {
+                if (! optional($this->user)->has_confirmed_two_factor) {
                     // THIS is where we can force 2fa...
                     return $this->attemptAuth($data);
                 }

--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -86,7 +86,7 @@ class Login extends FilamentLogin
                 $this->user = $model::where($this->loginColumn, $data[$this->fieldType])->first();
 
                 // If the user hasn't setup 2FA, authenticate and exit early.
-                if (! optional($this->user)->has_confirmed_two_factor) {
+                if ($this->user && !$this->user->has_confirmed_two_factor) {
                     // THIS is where we can force 2fa...
                     return $this->attemptAuth($data);
                 }


### PR DESCRIPTION
Fixes the error: Attempt to read property "has_confirmed_two_factor" on null: vendor/jeffgreco13/filament-breezy/src/Http/Livewire/Auth/Login.php:89

How to replicate error:

Activate 2f-Auth and try to authenticate with a nonexistent user.

You got the error: 

```Attempt to read property "has_confirmed_two_factor" on null: vendor/jeffgreco13/filament-breezy/src/Http/Livewire/Auth/Login.php:89```

