### PR TITLE
Bugfix: Avoid detecting loginColumn based on the username field value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,24 @@ Filament::serving(function () {
 
 *NOTE:* in order to add new sections to the Profile page, you will need to extend the class and publish/create your own views. The above method will only allow for adding new fields to the existing Personal Information or Password forms.
 
+
+#### Using a Column Other Than email for Login
+
+You may want to authenticate your users using a column other than `email` in your Authenticatable model. After you have setup your database, you can change the column in the config:
+
+```php
+"fallback_login_field" => "username",
+```
+
+Optionally, update the field label in your language file:
+
+```php
+"fields" => [
+   //
+   "login" => "Username",
+   //
+```
+
 ### NEW: Password Confirmation Button Action
 
 Since v1.3.0, Breezy has a `PasswordButtonAction` shortcut which extends the default Page\ButtonAction class. This button action will prompt the user to enter their password for sensitive actions (eg. delete), then will not ask for password again for the # of seconds defined in the filament-breezy config (default 300s).

--- a/config/filament-breezy.php
+++ b/config/filament-breezy.php
@@ -42,6 +42,12 @@ return [
     "users_table" => "users",
     /*
     |--------------------------------------------------------------------------
+    | The column to use for login/username authentication. NOTE: this may change to just 'login_field' in a later release.
+    */
+    "fallback_login_field" => "email",
+
+    /*
+    |--------------------------------------------------------------------------
     | Enable Two-Factor Authentication (2FA).
     */
     "enable_2fa" => false,
@@ -60,14 +66,6 @@ return [
     | Enable or disable registration.
     */
     "enable_registration" => true,
-    /*
-
-    /*
-    |--------------------------------------------------------------------------
-    | Extra column to check in users table if a user doesn't enter a valid email. Example: username
-    */
-    "fallback_login_field" => "email",
-
     /*
     |--------------------------------------------------------------------------
     | Path to registration Livewire component.

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -115,7 +115,7 @@ return [
     ],
     "fields" => [
         "email" => "Email",
-        "login" => "login",
+        "login" => "Login",
         "name" => "Name",
         "password" => "Password",
         "password_confirm" => "Password confirm",

--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -60,12 +60,10 @@ class Login extends FilamentLogin
         // Form data
         $data = $this->showCodeForm ? $this->twoFactorForm->getState() : $this->form->getState();
 
-        // login field
-        $this->fieldType = config('filament-breezy.fallback_login_field') == 'email' ? 'email' : 'login';
         // user column
-        if (isset($data[$this->fieldType])) {
-            $this->loginColumn = filter_var($data[$this->fieldType], FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
-        }
+        $this->loginColumn = config('filament-breezy.fallback_login_field');
+        // login field
+        $this->fieldType = $this->loginColumn === 'email' ? 'email' : 'login';
 
         if (config('filament-breezy.enable_2fa')) {
             if ($this->showCodeForm) {

--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -11,12 +11,12 @@ use Filament\Http\Livewire\Concerns\CanNotify;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 use Illuminate\Contracts\View\View;
 use JeffGreco13\FilamentBreezy\FilamentBreezy;
+use Illuminate\Support\Arr;
 
 class Login extends FilamentLogin
 {
     use CanNotify;
 
-    public $fieldType;
     public $loginColumn;
     public $showCodeForm = false;
     public $usingRecoveryCode = false;
@@ -46,7 +46,7 @@ class Login extends FilamentLogin
         try {
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {
-            $this->addError($this->fieldType, __('filament::login.messages.throttled', [
+            $this->addError($this->loginColumn, __('filament::login.messages.throttled', [
                 'seconds' => $exception->secondsUntilAvailable,
                 'minutes' => ceil($exception->secondsUntilAvailable / 60),
             ]));
@@ -59,11 +59,6 @@ class Login extends FilamentLogin
     {
         // Form data
         $data = $this->showCodeForm ? $this->twoFactorForm->getState() : $this->form->getState();
-
-        // user column
-        $this->loginColumn = config('filament-breezy.fallback_login_field');
-        // login field
-        $this->fieldType = $this->loginColumn === 'email' ? 'email' : 'login';
 
         if (config('filament-breezy.enable_2fa')) {
             if ($this->showCodeForm) {
@@ -81,7 +76,7 @@ class Login extends FilamentLogin
                 $this->doRateLimit();
 
                 $model = Filament::auth()->getProvider()->getModel();
-                $this->user = $model::where($this->loginColumn, $data[$this->fieldType])->first();
+                $this->user = $model::where($this->loginColumn, $data[$this->loginColumn])->first();
 
                 // If the user hasn't setup 2FA, authenticate and exit early.
                 if (! $this->user->has_confirmed_two_factor) {
@@ -90,7 +85,7 @@ class Login extends FilamentLogin
                 }
 
                 if (! $this->user || ! Filament::auth()->getProvider()->validateCredentials($this->user, ['password' => $data['password']])) {
-                    $this->addError($this->fieldType, __('filament::login.messages.failed'));
+                    $this->addError($this->loginColumn, __('filament::login.messages.failed'));
 
                     return null;
                 }
@@ -111,10 +106,10 @@ class Login extends FilamentLogin
     {
         // ->attempt will actually log the person in, then the response sends them to the dashboard. We need to catch the auth, show the code prompt, then log them in.
         if (! Filament::auth()->attempt([
-            $this->loginColumn => $data[$this->fieldType],
+            $this->loginColumn => $data[$this->loginColumn],
             'password' => $data['password'],
         ], $data['remember'])) {
-            $this->addError($this->fieldType, __('filament::login.messages.failed'));
+            $this->addError($this->loginColumn, __('filament::login.messages.failed'));
 
             return null;
         }
@@ -142,26 +137,32 @@ class Login extends FilamentLogin
 
     protected function getFormSchema(): array
     {
-        return config('filament-breezy.fallback_login_field') == 'email' ?
-        parent::getFormSchema() : [
-            TextInput::make('login')
-            ->label(__('filament-breezy::default.fields.login'))
-            ->required()
-            ->autocomplete(),
-            TextInput::make('password')
-            ->label(__('filament::login.fields.password.label'))
-            ->password()
-                ->required(),
-            Checkbox::make('remember')
-            ->label(__('filament::login.fields.remember.label')),
-        ];
+        $parentSchema = parent::getFormSchema();
+        if ($this->loginColumn !== 'email'){
+            // Pop off the email field and replace it with loginColumn
+            unset($parentSchema[0]);
+            $parentSchema = Arr::prepend($parentSchema,
+                TextInput::make($this->loginColumn)
+                    ->label(__('filament-breezy::default.fields.login'))
+                    ->required()
+                    ->autocomplete()
+            );
+        }
+        return $parentSchema;
+    }
+
+    public function boot(): void
+    {
+        // user column
+        $this->loginColumn = config('filament-breezy.fallback_login_field');
     }
 
     public function mount(): void
     {
         parent::mount();
-        if ($email = request()->query("email", "")) {
-            $this->form->fill(["email" => $email]);
+
+        if ($login = request()->query($this->loginColumn, "")) {
+            $this->form->fill([$this->loginColumn => $login]);
         }
         if (request()->query("reset")) {
             $this->notify("success", __("passwords.reset"), true);


### PR DESCRIPTION
Issue: If you try to authenticate a user with email like `foo@bar` the form is submitted with no validation and the authentication process fails with the next error:

```SQLSTATE[42703]: Undefined column: 7 ERROR: column "username" does not exist LINE 1: select * from "users" where "username" = $1 limit 1 ^ (SQL: select * from "users" where "username" = asdas limit 1) ```

The problem is the process detects the columName value based on the email field content:

```
        if (isset($data[$this->fieldType])) {
            $this->loginColumn = filter_var($data[$this->fieldType], FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
        }
```

The PR fixes that error by getting the column name from the config file and not using the email/username value, leaving it on the developer side what column should use.

Another possible solution is adding in the email field the rule `email:rfc,dns` but it's a terrible mistake to detect the columnName based on the value of a field.
