### PR TITLE
Bugfix: Avoid to get the registration form using the direct URL.

### DIFF
--- a/src/Http/Livewire/Auth/Register.php
+++ b/src/Http/Livewire/Auth/Register.php
@@ -19,6 +19,15 @@ class Register extends Component implements Forms\Contracts\HasForms
     public $password;
     public $password_confirm;
 
+    public function booted() : void
+    {
+        if(! config('filament-breezy.enable_registration', true)) {
+            redirect(config('filament.home_url', '/'));
+
+            return;
+        }
+    }
+
     public function mount()
     {
         if (Filament::auth()->check()) {


### PR DESCRIPTION
If you try to register using the URL (https://localhost/admin/register) in the browser, the registration form is displayed and allows the user to register even when the config file has `enable_registration = false`

The PR fixes the behavior above.