### PR TITLE
Address compatibility issues with HasBreezyTwoFactor::getActions()

### DIFF
--- a/src/Traits/HasBreezyTwoFactor.php
+++ b/src/Traits/HasBreezyTwoFactor.php
@@ -65,7 +65,7 @@ trait HasBreezyTwoFactor
         $this->showing_two_factor_recovery_codes = true;
     }
 
-    protected function getActions(): array | null
+    protected function getActions(): ?array
     {
         $actions = parent::getActions() ?? [];
         if (config('filament-breezy.enable_2fa')) {


### PR DESCRIPTION
Updating method return type.

It would appear that there's now an error:
```bash
  Declaration of JeffGreco13\FilamentBreezy\Traits\HasBreezyTwoFactor::getActions(): ?array must be compatible with Filament\Pages\Page::getActions(): array

  at vendor/jeffgreco13/filament-breezy/src/Traits/HasBreezyTwoFactor.php:68
     64▕         $this->notify('success', __('filament-breezy::default.profile.2fa.confirmation.success_notification'));
     65▕         $this->showing_two_factor_recovery_codes = true;
     66▕     }
     67▕
  ➜  68▕     protected function getActions(): array | null
```

I got this error when updating via composer:
```bash
$ composer update                                                                                                                                                                    ~/dev/caliber/admin
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 9 updates, 0 removals
...
  - Upgrading filament/filament (v2.12.28 => v2.13.2)
  - Upgrading filament/forms (v2.12.28 => v2.13.2)
  - Upgrading filament/support (v2.12.28 => v2.13.2)
  - Upgrading filament/tables (v2.12.28 => v2.13.2)
  - Upgrading jeffgreco13/filament-breezy (v1.3.5 => v1.3.6)
...
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 9 updates, 0 removals
...
  - Downloading filament/support (v2.13.2)
  - Downloading filament/forms (v2.13.2)
  - Downloading filament/tables (v2.13.2)
...
  - Downloading filament/filament (v2.13.2)
  - Downloading jeffgreco13/filament-breezy (v1.3.6)
...
  - Upgrading filament/support (v2.12.28 => v2.13.2): Extracting archive
  - Upgrading filament/forms (v2.12.28 => v2.13.2): Extracting archive
  - Upgrading filament/tables (v2.12.28 => v2.13.2): Extracting archive
...
  - Upgrading filament/filament (v2.12.28 => v2.13.2): Extracting archive
  - Upgrading jeffgreco13/filament-breezy (v1.3.5 => v1.3.6): Extracting archive
Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
Generating optimized autoload files
```