### PR TITLE
feat: load MyProfile page from config

### DIFF
--- a/config/filament-breezy.php
+++ b/config/filament-breezy.php
@@ -83,6 +83,11 @@ return [
     "email_verification_component_path" => \JeffGreco13\FilamentBreezy\Http\Livewire\Auth\Verify::class,
     /*
     |--------------------------------------------------------------------------
+    | Path to Profile page component.
+    */
+    "profile_page_component_path" => \JeffGreco13\FilamentBreezy\Pages\MyProfile::class,
+    /*
+    |--------------------------------------------------------------------------
     | Where to redirect the user after registration.
     */
     "registration_redirect_url" => config("filament.home_url", "/"),

--- a/src/FilamentBreezyServiceProvider.php
+++ b/src/FilamentBreezyServiceProvider.php
@@ -64,7 +64,7 @@ class FilamentBreezyServiceProvider extends PluginServiceProvider
     protected function getPages(): array
     {
         return config("filament-breezy.enable_profile_page")
-            ? [Pages\MyProfile::class]
+            ? [config("filament-breezy.profile_page_component_path")]
             : [];
     }
 }


### PR DESCRIPTION
I was having hard time to extend MyProfile page. I think in this way developers will easily extend it. Just like other components

So, when we need to extend the ```MyProfile::class``` just need to create Filament Page.
And then update the config. ```"profile_page_component_path" => \App\Filament\Pages\MyProfile::class```