### PR TITLE
fix: auth route prefixes and ResetPassword override

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -11,7 +11,7 @@
         @if(config("filament-breezy.enable_registration"))
         <p class="mt-2 text-sm text-center">
             {{ __('filament-breezy::default.or') }}
-            <a class="text-primary-600" href="{{route('register')}}">
+            <a class="text-primary-600" href="{{route('filament.register')}}">
                 {{ strtolower(__('filament-breezy::default.registration.heading')) }}
             </a>
         </p>
@@ -25,6 +25,6 @@
     </x-filament::button>
 
     <div class="text-center">
-        <a class="text-primary-600 hover:text-primary-700" href="{{route('password.request')}}">{{ __('filament-breezy::default.login.forgot_password_link') }}</a>
+        <a class="text-primary-600 hover:text-primary-700" href="{{route('filament.password.request')}}">{{ __('filament-breezy::default.login.forgot_password_link') }}</a>
     </div>
 </x-filament-breezy::auth-card>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,19 +9,19 @@ Route::domain(config("filament.domain"))
     ->group(function () {
         // Login will be replaced in the Filament config.
         if (config("filament-breezy.enable_registration")) {
-            Route::get("/register", config('filament-breezy.registration_component_path'))->name("register");
+            Route::get("/register", config('filament-breezy.registration_component_path'))->name("filament.register");
         }
         Route::get("/password/reset", config('filament-breezy.password_reset_component_path'))->name(
-            "password.request"
+            "filament.password.request"
         );
 
         Route::get("/password/reset/{token}", config('filament-breezy.password_reset_component_path'))->name(
-            "password.reset"
+            "filament.password.reset"
         );
 
         Route::get("email/verify", config('filament-breezy.email_verification_component_path'))
             ->middleware(["throttle:6,1","auth"])
-            ->name("verification.notice");
+            ->name("filament.verification.notice");
 
         Route::get("email/verify/{id}/{hash}", [
             EmailVerificationController::class,

--- a/src/FilamentBreezyServiceProvider.php
+++ b/src/FilamentBreezyServiceProvider.php
@@ -11,6 +11,7 @@ use JeffGreco13\FilamentBreezy\Http\Livewire\BreezySanctumTokens;
 use JeffGreco13\FilamentBreezy\Pages\MyProfile;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
+use Illuminate\Auth\Notifications\ResetPassword;
 
 class FilamentBreezyServiceProvider extends PluginServiceProvider
 {
@@ -59,6 +60,10 @@ class FilamentBreezyServiceProvider extends PluginServiceProvider
                 ]);
             });
         }
+
+        ResetPassword::createUrlUsing(function ($user, string $token) {
+            return route('filament.password.reset',['token'=>$token]);
+        });
     }
 
     protected function getPages(): array

--- a/src/FilamentBreezyServiceProvider.php
+++ b/src/FilamentBreezyServiceProvider.php
@@ -5,13 +5,13 @@ namespace JeffGreco13\FilamentBreezy;
 use Filament\Facades\Filament;
 use Filament\Navigation\UserMenuItem;
 use Filament\PluginServiceProvider;
+use Illuminate\Auth\Notifications\ResetPassword;
 use JeffGreco13\FilamentBreezy\Commands\FilamentBreezyCommand;
 use JeffGreco13\FilamentBreezy\Http\Livewire\Auth;
 use JeffGreco13\FilamentBreezy\Http\Livewire\BreezySanctumTokens;
 use JeffGreco13\FilamentBreezy\Pages\MyProfile;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
-use Illuminate\Auth\Notifications\ResetPassword;
 
 class FilamentBreezyServiceProvider extends PluginServiceProvider
 {
@@ -62,7 +62,7 @@ class FilamentBreezyServiceProvider extends PluginServiceProvider
         }
 
         ResetPassword::createUrlUsing(function ($user, string $token) {
-            return route('filament.password.reset',['token'=>$token]);
+            return route('filament.password.reset', ['token' => $token]);
         });
     }
 


### PR DESCRIPTION
Add filament. prefix to all auth routes except verification.verify.
At this time, no simple fix to override sendPasswordResetNotification() route