### PR TITLE
Fix verify email / reset password routes.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::domain(config("filament.domain"))
             "__invoke",
         ])
             ->middleware([Authenticate::class,"signed"])
-            ->name("verification.verify");
+            ->name("filament.verification.verify");
 
         Route::middleware(config("filament.middleware.auth"))->group(
             function (): void {

--- a/src/FilamentBreezyServiceProvider.php
+++ b/src/FilamentBreezyServiceProvider.php
@@ -6,6 +6,10 @@ use Filament\Facades\Filament;
 use Filament\Navigation\UserMenuItem;
 use Filament\PluginServiceProvider;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\URL;
 use JeffGreco13\FilamentBreezy\Commands\FilamentBreezyCommand;
 use JeffGreco13\FilamentBreezy\Http\Livewire\Auth;
 use JeffGreco13\FilamentBreezy\Http\Livewire\BreezySanctumTokens;
@@ -63,6 +67,17 @@ class FilamentBreezyServiceProvider extends PluginServiceProvider
 
         ResetPassword::createUrlUsing(function ($user, string $token) {
             return route('filament.password.reset', ['token' => $token]);
+        });
+
+        VerifyEmail::createUrlUsing(function ($notifiable) {
+            return URL::temporarySignedRoute(
+                'filament.verification.verify',
+                Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
+                [
+                    'id' => $notifiable->getKey(),
+                    'hash' => sha1($notifiable->getEmailForVerification()),
+                ]
+            );
         });
     }
 

--- a/src/FilamentBreezyServiceProvider.php
+++ b/src/FilamentBreezyServiceProvider.php
@@ -65,8 +65,11 @@ class FilamentBreezyServiceProvider extends PluginServiceProvider
             });
         }
 
-        ResetPassword::createUrlUsing(function ($user, string $token) {
-            return route('filament.password.reset', ['token' => $token]);
+        ResetPassword::createUrlUsing(function ($notifiable, string $token) {
+            return route('filament.password.reset', [
+                'token' => $token,
+                'email' => $notifiable->getEmailForPasswordReset(),
+            ]);
         });
 
         VerifyEmail::createUrlUsing(function ($notifiable) {


### PR DESCRIPTION
## small enhancement to verify/reset emails.
- [change route to filament namespace.](https://github.com/jeffgreco13/filament-breezy/pull/102/commits/7cd270943b3b1d18423c366807dbd78542b47b5b)
- [register new URL generator in service provider](https://github.com/jeffgreco13/filament-breezy/pull/102/commits/3f1cd37c0d31e6dc6048607d81cc0a4f50790bbe)
- [also on the fly, fixed the email not sent in ResetPassword](https://github.com/jeffgreco13/filament-breezy/pull/102/commits/9548124d335d769e67bd4c8a272a5df4c5ba0feb)

## Sources I learned from:
- https://dev.to/frknasir/laravel-easily-customize-email-verification-url-58f9
- https://laravel.com/docs/9.x/urls#signed-urls
- https://laravel.com/docs/8.x/verification#the-email-verification-handler

## Some Concerns to keep in mind:
- https://github.com/jeffgreco13/filament-breezy/pull/102#discussion_r939690734
- https://github.com/jeffgreco13/filament-breezy/pull/102#discussion_r939690854
- I guess breezy should have his own `ResetPassword` and `VerifyEmail` notifications which should be overridden in instructions. [Check out this Stackoverflow From me](https://stackoverflow.com/a/73269179/8623062) may explain the previous point more.

## Related
- PR #101
- PR #100
- Issue #99 should be fine too
- PR #98
- PR #97 
- [Discord Chat](https://discord.com/channels/883083792112300104/935091455280709672/1004199011621802064)