### PR TITLE
Fix typo in lang file (change 'ou' to 'or')

### DIFF
--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -2,7 +2,7 @@
 
 return [
     "login" => [
-        "username_or_email" => "Username ou Email",
+        "username_or_email" => "Username or Email",
         "forgot_password_link" => "Forgot password?",
         "create_an_account" => "create an account",
     ],


### PR DESCRIPTION
Very confident this is a typo, as the lang key specifies 'or'.