### PR TITLE
Fix to spanish translation in fields.login

### DIFF
--- a/resources/lang/es/default.php
+++ b/resources/lang/es/default.php
@@ -121,7 +121,7 @@ return [
     ],
     "fields" => [
         "email" => "Correo electrónico",
-        "login" => "Pengguna",
+        "login" => "Usuario",
         "name" => "Nombre",
         "password" => "Contraseña",
         "password_confirm" => "Confirmar la contraseña",


### PR DESCRIPTION
'Pengguna' it's not a spanish word. I feel like just 'Login' would be acceptable, but I went with 'Usuario' (User) because it's more spanish.