### PR TITLE
fix: fix translation to be more concise with the performed action

### DIFF
--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -48,7 +48,7 @@ return [
         "submit" => [
             "label" => "Uitloggen",
         ],
-        "notification_success" => "Er is een e-mail verstuurd met instructies om een nieuw wachtwoord in te stellen.",
+        "notification_success" => "Er is een e-mail verstuurd met instructies om je e-mailadres te verifiëren.",
         "notification_resend" => "Verificatie email opnieuw verstuurd.",
         "before_proceeding" => "Voordat je verder gaat, controleer je e-mail voor een verificatie link.",
         "not_receive" => "Indien je geen e-mail ontvangen hebt,",


### PR DESCRIPTION
The current translation showed the user the verification mail had instructions to configure a new password. This has now been rephrased to instructions for verifying their mail address.