### PR TITLE
remove strtolower() function

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -12,7 +12,7 @@
         <p class="mt-2 text-sm text-center">
             {{ __('filament-breezy::default.or') }}
             <a class="text-primary-600" href="{{route(config('filament-breezy.route_group_prefix').'register')}}">
-                {{ strtolower(__('filament-breezy::default.registration.heading')) }}
+                {{ __('filament-breezy::default.registration.heading') }}
             </a>
         </p>
         @endif


### PR DESCRIPTION
some languages like german need upper and lower case for correct grammar