### PR TITLE
Fixed compatibility with upstream Filament v3 changes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,12 +8,14 @@ Route::name('filament.')
     ->group(function () {
         foreach (Filament::getPanels() as $panel) {
             $panelId = $panel->getId();
-            Route::domain($panel->getDomain())
-                ->middleware($panel->getMiddleware())
-                ->name("{$panelId}.")
-                ->prefix($panel->getPath())
-                ->group(function () use ($panel) {
-                    Route::get('/two-factor-authentication',TwoFactorPage::class)->name('auth.two-factor');
-                });
+            foreach ((empty($domains) ? [null] : $domains) as $domain) {
+                Route::domain($domain)
+                    ->middleware($panel->getMiddleware())
+                    ->name("{$panelId}.")
+                    ->prefix($panel->getPath())
+                    ->group(function () use ($panel) {
+                        Route::get('/two-factor-authentication', TwoFactorPage::class)->name('auth.two-factor');
+                    });
+            }
         }
     });


### PR DESCRIPTION
Per [#7398](https://github.com/filamentphp/filament/pull/7398 ), the `getDomain()` changed to `getDomains()`

Otherwise you'd see:
>    BadMethodCallException 
>  Method Filament\Panel::getDomain does not exist.
