### PR TITLE
Fix Routes on Version 2.x for Multiple Domains Compatibility

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,14 +8,15 @@ Route::name('filament.')
     ->group(function () {
         foreach (Filament::getPanels() as $panel) {
             $panelId = $panel->getId();
-            foreach ((empty($domains) ? [null] : $domains) as $domain) {
+            foreach ($panel->getDomains() as $domain){
                 Route::domain($domain)
-                    ->middleware($panel->getMiddleware())
-                    ->name("{$panelId}.")
-                    ->prefix($panel->getPath())
-                    ->group(function () use ($panel) {
-                        Route::get('/two-factor-authentication', TwoFactorPage::class)->name('auth.two-factor');
-                    });
+                ->middleware($panel->getMiddleware())
+                ->name("{$panelId}.")
+                ->prefix($panel->getPath())
+                ->group(function () use ($panel) {
+                    Route::get('/two-factor-authentication',TwoFactorPage::class)->name('auth.two-factor');
+                });
             }
+
         }
     });


### PR DESCRIPTION
This pull request aims to address compatibility issues with multiple domains after the recent changes in Filament's API. With the introduction of the `getDomains()` method and the deprecation of `getDomain()`, this update ensures that the routes in version 2.x of the project function correctly with multiple domains.

See filament PR [here](https://github.com/filamentphp/filament/pull/7398).