### PR TITLE
Fixed typo in #194

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ Route::name('filament.')
     ->group(function () {
         foreach (Filament::getPanels() as $panel) {
             $panelId = $panel->getId();
+            $domains = $panel->getDomains();
             foreach ((empty($domains) ? [null] : $domains) as $domain) {
                 Route::domain($domain)
                     ->middleware($panel->getMiddleware())


### PR DESCRIPTION
Follow-up to #194 

The `$domains` was undeclared accidentally. The other fix in #196 also doesn't account for the default case of empty domains:
```
> Filament\Facades\Filament::getPanels()['app']->getDomains()
= []
```