### PR TITLE
Made Sanctum ability columns configurable

### DIFF
--- a/src/Livewire/SanctumTokens.php
+++ b/src/Livewire/SanctumTokens.php
@@ -17,6 +17,8 @@ class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTa
 
     protected string $modalWidth = "md";
 
+    protected int $abilityColumns = 2;
+
     public $user;
     public ?string $plainTextToken;
 
@@ -66,7 +68,7 @@ class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTa
             Forms\Components\CheckboxList::make('abilities')
                 ->label(__('filament-breezy::default.fields.abilities'))
                 ->options(filament('filament-breezy')->getSanctumPermissions())
-                ->columns(2)
+                ->columns($this->abilityColumns)
                 ->required(),
             Forms\Components\DatePicker::make('expires_at')
                 ->label(__('filament-breezy::default.fields.token_expiry'))


### PR DESCRIPTION
When there are more than just a handful abilities the default 2 columns mean that the form can get very long, so I've added a `SanctumTokens::$abilityColumns` property. It's now possible to adjust the modal form with just something like this:

```php
use Jeffgreco13\FilamentBreezy\Livewire\SanctumTokens;

class Sanctum extends SanctumTokens
{
    protected string $modalWidth = 'xl';

    protected int $abilityColumns = 3;
}
```