### PR TITLE
Implemented basic profile component authorization

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -169,11 +169,14 @@ class BreezyCore implements Plugin
 
     public function getRegisteredMyProfileComponents(): array
     {
-        $components = $this->registeredMyProfileComponents;
+        $components = collect($this->registeredMyProfileComponents)->filter(
+            fn (string $component) => $component::canView()
+        );
+
         if ($this->shouldForceTwoFactor()){
-            $components = Arr::only($components,['two_factor_authentication']);
+            $components = $components->only(['two_factor_authentication']);
         }
-        return collect($components)->all();
+        return $components->all();
     }
 
     public function passwordUpdateRules(array | Password $rules, bool $requiresCurrentPassword = true)

--- a/src/Livewire/MyProfileComponent.php
+++ b/src/Livewire/MyProfileComponent.php
@@ -24,4 +24,8 @@ class MyProfileComponent extends Component implements HasForms, HasActions
         return view($this->view);
     }
 
+    public static function canView(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
I've added a basic static method `MyProfileComponent::canView()`. This is then being checked in `BreezyCore::getRegisteredMyProfileComponents()`. I've implemented this mainly for Sanctum tokens, but it might come in handy for other custom sections as well. It could then be used like so:

```php
use Jeffgreco13\FilamentBreezy\Livewire\SanctumTokens;

class Sanctum extends SanctumTokens
{
    public static function canView(): bool
    {
        return current_member()->canUseFeature(API::class);
    }
}
```