### PR TITLE
Added ability to use a custom 2fa page

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,22 @@ class User extends Authenticatable
 ```php
 BreezyCore::make()
     ->enableTwoFactorAuthentication(
-        force: false // force the user to enable 2FA before they can use the application (default = false)
+        force: false, // force the user to enable 2FA before they can use the application (default = false)
+        action: CustomTwoFactorPage::class // optionally, use a custom 2FA page
     )
+```
+
+3. Adjust the 2FA page
+
+The Breezy 2FA page can be swapped for a custom implementation (see above), same as the Filament auth pages. This allows, for example, to define a custom auth layout like so:
+
+```php
+use Jeffgreco13\FilamentBreezy\Pages\TwoFactorPage;
+
+class CustomTwoFactorPage extends TwoFactorPage
+{
+    protected static string $layout = 'custom.auth.layout.view';
+}
 ```
 
 ### Sanctum Personal Access tokens

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,6 @@
 
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Route;
-use Jeffgreco13\FilamentBreezy\Pages\TwoFactorPage;
 
 Route::name('filament.')
     ->group(function () {
@@ -16,7 +15,10 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy) {
-                        Route::get($hasTenancy ? '/{tenant}/two-factor-authentication' : '/two-factor-authentication', TwoFactorPage::class)->name('auth.two-factor');
+                        $route = $hasTenancy ? '/{tenant}/two-factor-authentication' : '/two-factor-authentication';
+                        $action = filament('filament-breezy')->getTwoFactorRouteAction();
+
+                        Route::get($route, $action)->name('auth.two-factor');
                     });
             }
         }

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -27,6 +27,7 @@ use Jeffgreco13\FilamentBreezy\Livewire\SanctumTokens;
 use Jeffgreco13\FilamentBreezy\Livewire\UpdatePassword;
 use Jeffgreco13\FilamentBreezy\Middleware\MustTwoFactor;
 use Jeffgreco13\FilamentBreezy\Livewire\TwoFactorAuthentication;
+use Jeffgreco13\FilamentBreezy\Pages\TwoFactorPage;
 
 class BreezyCore implements Plugin
 {
@@ -37,6 +38,7 @@ class BreezyCore implements Plugin
     protected $avatarUploadComponent;
     protected $twoFactorAuthentication;
     protected $forceTwoFactorAuthentication;
+    protected $twoFactorRouteAction;
     protected $registeredMyProfileComponents = [];
     protected $passwordUpdateRules = ['min:8'];
     protected bool $passwordUpdateRequireCurrent = true;
@@ -198,16 +200,22 @@ class BreezyCore implements Plugin
         return $this->{$key}['shouldRegisterNavigation'];
     }
 
-    public function enableTwoFactorAuthentication(bool $condition = true, bool $force = false)
+    public function enableTwoFactorAuthentication(bool $condition = true, bool $force = false, string | Closure | array | null $action = TwoFactorPage::class)
     {
         $this->twoFactorAuthentication = $condition;
         $this->forceTwoFactorAuthentication = $force;
+        $this->twoFactorRouteAction = $action;
         return $this;
     }
 
     public function getForceTwoFactorAuthentication(): bool
     {
         return $this->forceTwoFactorAuthentication;
+    }
+
+    public function getTwoFactorRouteAction(): string | Closure | array | null
+    {
+        return $this->twoFactorRouteAction;
     }
 
     public function getEngine()


### PR DESCRIPTION
The Filament auth pages can be user-defined and this PR adds that same ability to Breezy. This is especially useful if you want to style the auth pages by setting a custom layout, like so:

```php
use Jeffgreco13\FilamentBreezy\Pages\TwoFactorPage;

class TwoFactor extends TwoFactorPage
{
    protected static string $layout = 'layouts.auth';
}
```