### PR TITLE
Fix incorrect route name in MustTwoFactor middleware

### DIFF
--- a/src/Middleware/MustTwoFactor.php
+++ b/src/Middleware/MustTwoFactor.php
@@ -21,7 +21,7 @@ class MustTwoFactor
             !str($request->route()->getName())->contains('logout')
         ){
             $breezy = filament('filament-breezy');
-            $myProfileRouteName = 'filament.' . filament()->getCurrentPanel()->getPath() . '.pages.my-profile';
+            $myProfileRouteName = 'filament.' . filament()->getCurrentPanel()->getId() . '.pages.my-profile';
 
             if (filament()->hasTenancy()){
                 if (!$tenantId = request()->route()->parameter('tenant')){


### PR DESCRIPTION
To generate a page's route name, the panel's ID should be used instead of its path.