### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ use Filament\Forms\Components\FileUpload;
 BreezyCore::make()
     ->avatarUploadComponent(fn($fileUpload) => $fileUpload->disableLabel())
     // OR, replace with your own component
-    ->avatarUploadComponent(fn() => FileUpload::make('myUpload')->disk('profile-photos'))
+    ->avatarUploadComponent(fn() => FileUpload::make('avatar_url')->disk('profile-photos'))
 ```
 
 #### Customize password update


### PR DESCRIPTION
changed the name of the column from myUplaod  to avatat_url. Otherwise, you would have a column in the database called myUpload and filament is searching for avatar_url; therefore null. 

Should I also mention that you should create the column for the avatar, or is that implied from the FileUpload component?