### PR TITLE
Set profile title to profile heading

### DIFF
--- a/src/Pages/MyProfilePage.php
+++ b/src/Pages/MyProfilePage.php
@@ -12,6 +12,11 @@ class MyProfilePage extends Page
 
     protected static string $view = 'filament-breezy::filament.pages.my-profile';
 
+    public function getTitle(): string
+    {
+        return __('filament-breezy::default.profile.my_profile');
+    }
+
     public function getHeading(): string
     {
         return __('filament-breezy::default.profile.my_profile');


### PR DESCRIPTION
Just noticed that the page title for the my profile page is always set to `My Profile Page` because Filament generates titles based on the class name. This PR sets the page title for the profile page to the same value as the heading.