### PR TITLE
Fix authenticatable(), add LoginSucess event back in

### DIFF
--- a/src/Events/LoginSuccess.php
+++ b/src/Events/LoginSuccess.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jeffgreco13\FilamentBreezy\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LoginSuccess
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Models/BreezySession.php
+++ b/src/Models/BreezySession.php
@@ -52,7 +52,7 @@ class BreezySession extends Model
 
     public function authenticatable()
     {
-        $this->morphTo();
+        return $this->morphTo();
     }
 
     public function confirm()

--- a/src/Models/BreezySession.php
+++ b/src/Models/BreezySession.php
@@ -6,7 +6,7 @@ use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use JeffGreco13\FilamentBreezy\Events\LoginSuccess;
+use Jeffgreco13\FilamentBreezy\Events\LoginSuccess;
 
 class BreezySession extends Model
 {

--- a/src/Models/BreezySession.php
+++ b/src/Models/BreezySession.php
@@ -6,6 +6,7 @@ use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use JeffGreco13\FilamentBreezy\Events\LoginSuccess;
 
 class BreezySession extends Model
 {
@@ -57,6 +58,8 @@ class BreezySession extends Model
 
     public function confirm()
     {
+        event(new LoginSuccess($this->authenticatable));
+
         $this->update([
             'two_factor_confirmed_at' => now()
         ]);


### PR DESCRIPTION
Hey! We seem to have lost the LoginSuccess event after updating. This PR adds that event back in, and also changes the authenticatable call so it returns the relation.