### PR TITLE
Remove hyphen from 2fa input

### DIFF
--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -52,6 +52,8 @@ class TwoFactorPage extends SimplePage
                     <x-filament::link href="#" wire:click="toggleRecoveryCode()">'.($this->usingRecoveryCode ? __('filament-breezy::default.cancel') : __('filament-breezy::default.two_factor.recovery_code_link')) . '
                     </x-filament::link>')))
                 ->required()
+                ->mask('999-999')
+                ->dehydrateStateUsing(fn (string $state): string => str_replace('-', '', $state))
                 ->extraInputAttributes(['class' => 'text-center'])
                 ->autofocus(),
         ];

--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -52,8 +52,6 @@ class TwoFactorPage extends SimplePage
                     <x-filament::link href="#" wire:click="toggleRecoveryCode()">'.($this->usingRecoveryCode ? __('filament-breezy::default.cancel') : __('filament-breezy::default.two_factor.recovery_code_link')) . '
                     </x-filament::link>')))
                 ->required()
-                ->mask('999-999')
-                ->dehydrateStateUsing(fn (string $state): string => str_replace('-', '', $state))
                 ->extraInputAttributes(['class' => 'text-center'])
                 ->autofocus(),
         ];


### PR DESCRIPTION
Remove hyphen from 2fa code input because dehydrating state does not currently do anything other than it appends an additional digit.