### PR TITLE
Recheck $tenantId before querying $tenant

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -105,7 +105,7 @@ class BreezyCore implements Plugin
             if ($this->myProfile['shouldRegisterUserMenu']) {
                 if ($panel->hasTenancy()) {
                     $tenantId = request()->route()->parameter('tenant');
-                    if ($tenant = app($panel->getTenantModel())::where($panel->getTenantSlugAttribute() ?? 'id', $tenantId)->first()){
+                    if ($tenantId && $tenant = app($panel->getTenantModel())::where($panel->getTenantSlugAttribute() ?? 'id', $tenantId)->first()){
                         $panel->userMenuItems([
                             'account' => MenuItem::make()->url(Pages\MyProfilePage::getUrl(panel:$panel->getId(),tenant: $tenant)),
                         ]);


### PR DESCRIPTION
Of course we don't want any useless query at every livewire update, since it can't (and not necessary to) resolve the value of $tenantId in ajax requests (while the menu is already rendered). Below is the example from my project:

![image](https://github.com/jeffgreco13/filament-breezy/assets/26832856/72c89424-a360-4217-aece-2009fe871b46)

