### PR TITLE
unknown route error fix when 2fa is forced

### DIFF
--- a/src/Middleware/MustTwoFactor.php
+++ b/src/Middleware/MustTwoFactor.php
@@ -21,7 +21,7 @@ class MustTwoFactor
             !str($request->route()->getName())->contains('logout')
         ){
             $breezy = filament('filament-breezy');
-            $myProfileRouteName = 'filament.' . filament()->getCurrentPanel()->getPath() . '.pages.my-profile';
+            $myProfileRouteName = 'filament.' . filament()->getCurrentPanel()->getId() . '.pages.my-profile';
 
             if (filament()->hasTenancy()){
                 if (!$tenantId = request()->route()->parameter('tenant')){


### PR DESCRIPTION
This mr fixes 500 error when
```
 ->enableTwoFactorAuthentication(
                        force: true,
                    )
```
is set in AdminPanelProvider

