### PR TITLE
Improved redirect for login process

### DIFF
--- a/src/Middleware/MustTwoFactor.php
+++ b/src/Middleware/MustTwoFactor.php
@@ -27,9 +27,9 @@ class MustTwoFactor
                 if (!$tenantId = request()->route()->parameter('tenant')){
                     return $next($request);
                 }
-                $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor',['tenant'=>$tenantId]);
+                $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor',['tenant'=>$tenantId, 'next' => request()->getRequestUri()]);
             } else {
-                $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor');
+                $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor', ['next' => request()->getRequestUri()]);
             }
 
             if ($breezy->shouldForceTwoFactor() && !$request->routeIs($myProfileRouteName)){

--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -24,6 +24,9 @@ class TwoFactorPage extends SimplePage
     public $usingRecoveryCode = false;
     public $code;
 
+    #[Url]
+    public ?string $next;
+
     public function getTitle(): string
     {
         return __('filament-breezy::default.two_factor.heading');
@@ -123,6 +126,6 @@ class TwoFactorPage extends SimplePage
 
         // If it makes it to the bottom, we're going to set the session var and send them to the dashboard.
         filament('filament-breezy')->auth()->user()->setTwoFactorSession();
-        return redirect()->to(Filament::getHomeUrl());
+        return redirect()->to($this->next ?? Filament::getHomeUrl());
     }
 }

--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -13,6 +13,7 @@ use DanHarrin\LivewireRateLimiting\WithRateLimiting;
 use Filament\Http\Controllers\Auth\LogoutController;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Livewire\Attributes\Url;
 
 class TwoFactorPage extends SimplePage
 {


### PR DESCRIPTION
At the moment the login will always redirect to the homepage of the panel, this is the case if the user has gone to a specific URL or to direct to the homepage. For example if an unauthenticated user navigates to `/admin/posts/23` upon login they are redirected to `/admin`.

I have added the ability for the desired URL to be passed to the two factor authentication page to allow for the user to be redirected to that page upon a successful authentication. Now if an unauthenticated user navigates to `/admin/posts/23` upon login they are redirected to `/admin/posts/23`.