### PR TITLE
Add required tenant parameter to my-profile route

### DIFF
--- a/src/Middleware/MustTwoFactor.php
+++ b/src/Middleware/MustTwoFactor.php
@@ -22,18 +22,20 @@ class MustTwoFactor
         ){
             $breezy = filament('filament-breezy');
             $myProfileRouteName = 'filament.' . filament()->getCurrentPanel()->getId() . '.pages.my-profile';
+            $myProfileRouteParameters = [];
 
             if (filament()->hasTenancy()){
                 if (!$tenantId = request()->route()->parameter('tenant')){
                     return $next($request);
                 }
+                $myProfileRouteParameters = ['tenant' => $tenantId];
                 $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor',['tenant'=>$tenantId, 'next' => request()->getRequestUri()]);
             } else {
                 $twoFactorRoute = route('filament.' . filament()->getCurrentPanel()->getId() . '.auth.two-factor', ['next' => request()->getRequestUri()]);
             }
 
             if ($breezy->shouldForceTwoFactor() && !$request->routeIs($myProfileRouteName)){
-                return redirect()->route($myProfileRouteName);
+                return redirect()->route($myProfileRouteName, $myProfileRouteParameters);
             } else if (filament()->auth()->user()->hasConfirmedTwoFactor() && !filament()->auth()->user()->hasValidTwoFactorSession()) {
                 return redirect($twoFactorRoute);
             }


### PR DESCRIPTION
Fixes the following error:

```
Missing required parameter for [Route: filament.user.pages.my-profile] [URI: user/{tenant}/my-profile] [Missing parameter: tenant].
```

![CleanShot 2023-11-22 at 22 09 55@2x](https://github.com/jeffgreco13/filament-breezy/assets/388557/2125f410-f073-4556-97ff-645608964d66)
