### PR TITLE
Add feature to ignore MyProfile components

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ BreezyCore::make()
         )
 
 ```
+
+#### Exclude default My Profile components
+
+If you don't want a default My Profile page component to be used, you can exclude them using the `withoutMyProfileComponents` helper.
+
+```php
+BreezyCore::make()
+    ->withoutMyProfileComponents([
+        'update_password'
+    ])
+```
+
+
 #### Create custom My Profile components
 
 In Breezy v2, you can now create custom Livewire components for the My Profile page and append them easily.

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -39,6 +39,7 @@ class BreezyCore implements Plugin
     protected $twoFactorAuthentication;
     protected $forceTwoFactorAuthentication;
     protected $twoFactorRouteAction;
+    protected $ignoredMyProfileComponents = [];
     protected $registeredMyProfileComponents = [];
     protected $passwordUpdateRules = ['min:8'];
     protected bool $passwordUpdateRequireCurrent = true;
@@ -159,12 +160,18 @@ class BreezyCore implements Plugin
         ]);
     }
 
+    public function withoutMyProfileComponents(array $components)
+    {
+        $this->ignoredMyProfileComponents = $components;
+        return $this;
+    }
+
     public function myProfileComponents(array $components)
     {
-        $this->registeredMyProfileComponents = [
+        $this->registeredMyProfileComponents = Arr::except([
             ...$components,
             ...$this->registeredMyProfileComponents,
-        ];
+        ], $this->ignoredMyProfileComponents);
 
         return $this;
     }


### PR DESCRIPTION
Fixes https://github.com/jeffgreco13/filament-breezy/issues/291 by adding a method to ignore My Profile components from being added.

To use it, chain the `withoutMyProfileComponents` to your Filament plugin registration

```php
->plugin(
    BreezyCore::make()
        ->withoutMyProfileComponents([
            'update_password'
        ])
);
```