### PR TITLE
fix #283

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,7 @@ Route::name('filament.')
     ->group(function () {
         foreach (Filament::getPanels() as $panel) {
             $panelId = $panel->getId();
-            $domains = $panel->getDomains();
+            $domains = $panel->getDomain();
             $hasTenancy = $panel->hasTenancy();
             foreach ((empty($domains) ? [null] : $domains) as $domain) {
                 Route::domain($domain)


### PR DESCRIPTION
The method `getDomains`does not exist on the panel object in newer versions of filament. Therefore, installing breezy throws an error and makes the plugin unusable.
The new method name is `getDomain`. With this function, the installation process runs smoothly and the library is usable again.