### PR TITLE
Update MyProfile page configuration to support navigation groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ BreezyCore::make()
     ->myProfile(
         shouldRegisterUserMenu: true, // Sets the 'account' link in the panel User Menu (default = true)
         shouldRegisterNavigation: false, // Adds a main navigation item for the My Profile page (default = false)
+        navigationGroup: 'Settings', // Sets the navigation group for the My Profile page (default = null)
         hasAvatars: false, // Enables the avatar upload form component (default = false)
         slug: 'my-profile' // Sets the slug for the profile page (default = 'my-profile')
     )

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -130,7 +130,7 @@ class BreezyCore implements Plugin
         return Filament::getCurrentPanel();
     }
 
-    public function myProfile(bool $condition = true, bool $shouldRegisterUserMenu = true, bool $shouldRegisterNavigation = false, bool $hasAvatars = false, string $slug = 'my-profile'){
+    public function myProfile(bool $condition = true, bool $shouldRegisterUserMenu = true, bool $shouldRegisterNavigation = false, bool $hasAvatars = false, string $slug = 'my-profile', ?string $navigationGroup = null){
         $this->myProfile = get_defined_vars();
         return $this;
     }
@@ -210,6 +210,11 @@ class BreezyCore implements Plugin
     public function shouldRegisterNavigation(string $key)
     {
         return $this->{$key}['shouldRegisterNavigation'];
+    }
+    
+    public function getNavigationGroup(string $key)
+    {
+        return $this->{$key}['navigationGroup'] ?? null;
     }
 
     public function enableTwoFactorAuthentication(bool $condition = true, bool $force = false, string | Closure | array | null $action = TwoFactorPage::class)

--- a/src/Pages/MyProfilePage.php
+++ b/src/Pages/MyProfilePage.php
@@ -42,6 +42,10 @@ class MyProfilePage extends Page
         return filament('filament-breezy')->shouldRegisterNavigation('myProfile');
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return filament('filament-breezy')->getNavigationGroup('myProfile');
+    }
 
     public function getRegisteredMyProfileComponents(): array
     {


### PR DESCRIPTION
Adds a new option to set a navigation group for the my profile page

```php
    ->myProfile(
        shouldRegisterUserMenu: true, // Sets the 'account' link in the panel User Menu (default = true)
        shouldRegisterNavigation: false, // Adds a main navigation item for the My Profile page (default = false)
        navigationGroup: 'Settings', // Sets the navigation group for the My Profile page (default = null)
        hasAvatars: false, // Enables the avatar upload form component (default = false)
        slug: 'my-profile' // Sets the slug for the profile page (default = 'my-profile')
    )
```

![image](https://github.com/jeffgreco13/filament-breezy/assets/95144705/a1860352-9afc-439f-9e6d-be3f4dc82037)
