### PR TITLE
Add feature to customize the MyProfile page class

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ BreezyCore::make()
     )
 ```
 
+#### Custom My Profile page class
+
+You can also use a custom My Profile page class by extending the default one, and registering it with the plugin.
+
+```php
+BreezyCore::make()
+    ->myProfile()
+    ->customMyProfilePage(AccountSettingsPage::class),
+```
+
 #### Using avatars in your Panel
 
 The instructions for using custom avatars is found in the Filament v3 docs under [Setting up user avatars](https://filamentphp.com/docs/3.x/panels/users#setting-up-user-avatars).

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -45,6 +45,7 @@ class BreezyCore implements Plugin
     protected bool $passwordUpdateRequireCurrent = true;
     protected $sanctumTokens = false;
     protected $sanctumPermissions = ["create", "view", "update", "delete"];
+    protected ?string $customMyProfilePageClass = null;
 
     public function __construct(Google2FA $engine, Repository $cache = null)
     {
@@ -75,7 +76,7 @@ class BreezyCore implements Plugin
     {
         $collection = collect();
         if ($this->myProfile) {
-            $collection->push(Pages\MyProfilePage::class);
+            $collection->push($this->getMyProfilePageClass());
         }
         return $collection->toArray();
     }
@@ -132,6 +133,14 @@ class BreezyCore implements Plugin
 
     public function myProfile(bool $condition = true, bool $shouldRegisterUserMenu = true, bool $shouldRegisterNavigation = false, bool $hasAvatars = false, string $slug = 'my-profile'){
         $this->myProfile = get_defined_vars();
+        return $this;
+    }
+
+    /** @param class-string<Pages\MyProfilePage> $class */
+    public function customMyProfilePage(string $class)
+    {
+        $this->customMyProfilePageClass = $class;
+
         return $this;
     }
 
@@ -300,5 +309,9 @@ class BreezyCore implements Plugin
             return [$key => $item];
         })->toArray();
     }
-
+    
+    protected function getMyProfilePageClass(): string
+    {
+        return $this->customMyProfilePageClass ?? Pages\MyProfilePage::class;
+    }
 }


### PR DESCRIPTION
Makes it easier to do extensive customization, and could potentially fix https://github.com/jeffgreco13/filament-breezy/issues/219 and fix https://github.com/jeffgreco13/filament-breezy/issues/248

```php
BreezyCore::make()
    ->myProfile()
    ->customMyProfilePage(AccountSettingsPage::class),
```