### PR TITLE
Fix double HTML encoding of grid-section props

### DIFF
--- a/resources/views/livewire/personal-info.blade.php
+++ b/resources/views/livewire/personal-info.blade.php
@@ -1,4 +1,4 @@
-<x-filament-breezy::grid-section md=2 title="{{ __('filament-breezy::default.profile.personal_info.heading') }}" description="{{ __('filament-breezy::default.profile.personal_info.subheading') }}">
+<x-filament-breezy::grid-section md=2 :title="__('filament-breezy::default.profile.personal_info.heading')" :description="__('filament-breezy::default.profile.personal_info.subheading')">
     <x-filament::card>
         <form wire:submit.prevent="submit" class="space-y-6">
 

--- a/resources/views/livewire/sanctum-tokens.blade.php
+++ b/resources/views/livewire/sanctum-tokens.blade.php
@@ -1,4 +1,4 @@
-<x-filament-breezy::grid-section md=2 title="{{ __('filament-breezy::default.profile.sanctum.title') }}" description="{{ __('filament-breezy::default.profile.sanctum.description') }}">
+<x-filament-breezy::grid-section md=2 :title="__('filament-breezy::default.profile.sanctum.title')" :description="__('filament-breezy::default.profile.sanctum.description')">
         @if($plainTextToken)
             <div class="space-y-2 bg-warning-500">
                 <p class="text-sm">{{ __('filament-breezy::default.profile.sanctum.create.message') }}</p>

--- a/resources/views/livewire/two-factor-authentication.blade.php
+++ b/resources/views/livewire/two-factor-authentication.blade.php
@@ -1,4 +1,4 @@
-<x-filament-breezy::grid-section md=2 title="{{ __('filament-breezy::default.profile.2fa.title') }}" description="{{ __('filament-breezy::default.profile.2fa.description') }}">
+<x-filament-breezy::grid-section md=2 :title="__('filament-breezy::default.profile.2fa.title')" :description="__('filament-breezy::default.profile.2fa.description')">
 
     <x-filament::card>
 

--- a/resources/views/livewire/update-password.blade.php
+++ b/resources/views/livewire/update-password.blade.php
@@ -1,4 +1,4 @@
-<x-filament-breezy::grid-section md=2 title="{{ __('filament-breezy::default.profile.password.heading') }}" description="{{ __('filament-breezy::default.profile.password.subheading') }}">
+<x-filament-breezy::grid-section md=2 :title="__('filament-breezy::default.profile.password.heading')" :description="__('filament-breezy::default.profile.password.subheading')">
     <x-filament::card>
         <form wire:submit.prevent="submit" class="space-y-6">
 


### PR DESCRIPTION
This fixes the double encoding happening in grid-section.
It's visible in french for example:
![image](https://github.com/jeffgreco13/filament-breezy/assets/5481247/f925c54e-4f3b-4f18-baee-ae9adba79a81)
