### PR TITLE
fix jeffgreco13/filament-breezy#233

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -320,7 +320,7 @@ class BreezyCore implements Plugin
     public function shouldForceTwoFactor(): bool
     {
         if ($this->getCurrentPanel()->isEmailVerificationRequired()) {
-            return $this->forceTwoFactorAuthentication && !$this->auth()->user()?->hasConfirmedTwoFactor() && $this->auth()->user()?->hasVerifiedEmail();
+            return $this->forceTwoFactorAuthentication && ! $this->auth()->user()?->hasConfirmedTwoFactor() && $this->auth()->user()?->hasVerifiedEmail();
         }
 
         return $this->forceTwoFactorAuthentication && ! $this->auth()->user()?->hasConfirmedTwoFactor();

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -319,6 +319,10 @@ class BreezyCore implements Plugin
 
     public function shouldForceTwoFactor(): bool
     {
+        if ($this->getCurrentPanel()->isEmailVerificationRequired()) {
+            return $this->forceTwoFactorAuthentication && !$this->auth()->user()?->hasConfirmedTwoFactor() && $this->auth()->user()?->hasVerifiedEmail();
+        }
+
         return $this->forceTwoFactorAuthentication && ! $this->auth()->user()?->hasConfirmedTwoFactor();
     }
 


### PR DESCRIPTION
Using Filament's built-in `$panel->emailVerification()` functionality and `BreezyCore::make()->enableTwoFactorAuthentication(force: true)` creates an infinite redirect loop when the user clicks on the verification link.

This fix checks for email verification in Breezy's `shouldForceTwoFactor()` method.