### PR TITLE
Fix issue with token creation and expiry date

### DIFF
--- a/src/Livewire/SanctumTokens.php
+++ b/src/Livewire/SanctumTokens.php
@@ -8,6 +8,7 @@ use Filament\Notifications\Notification;
 use Filament\Tables;
 use Illuminate\Database\Eloquent\Builder;
 use Laravel\Sanctum\Sanctum;
+use Carbon\Carbon;
 
 class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTable
 {
@@ -89,7 +90,7 @@ class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTa
                 ->modalWidth($this->modalWidth)
                 ->form($this->getSanctumFormSchema())
                 ->action(function ($data) {
-                    $this->plainTextToken = $this->user->createToken($data['token_name'], array_values($data['abilities']))->plainTextToken;
+                    $this->plainTextToken = $this->user->createToken($data['token_name'], array_values($data['abilities']), $data['expires_at'] ? Carbon::createFromFormat('Y-m-d', $data['expires_at']): null)->plainTextToken;
                     Notification::make()
                         ->success()
                         ->title(__('filament-breezy::default.profile.sanctum.create.notify'))

--- a/src/Livewire/SanctumTokens.php
+++ b/src/Livewire/SanctumTokens.php
@@ -2,13 +2,13 @@
 
 namespace Jeffgreco13\FilamentBreezy\Livewire;
 
+use Carbon\Carbon;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Tables;
 use Illuminate\Database\Eloquent\Builder;
 use Laravel\Sanctum\Sanctum;
-use Carbon\Carbon;
 
 class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTable
 {
@@ -90,7 +90,7 @@ class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTa
                 ->modalWidth($this->modalWidth)
                 ->form($this->getSanctumFormSchema())
                 ->action(function ($data) {
-                    $this->plainTextToken = $this->user->createToken($data['token_name'], array_values($data['abilities']), $data['expires_at'] ? Carbon::createFromFormat('Y-m-d', $data['expires_at']): null)->plainTextToken;
+                    $this->plainTextToken = $this->user->createToken($data['token_name'], array_values($data['abilities']), $data['expires_at'] ? Carbon::createFromFormat('Y-m-d', $data['expires_at']) : null)->plainTextToken;
                     Notification::make()
                         ->success()
                         ->title(__('filament-breezy::default.profile.sanctum.create.notify'))


### PR DESCRIPTION
Filament breezy allows users to create and manage their sanctum tokens.
However, when creating a new token, the inserted "expires_at"-field isn't currently passed on. My commit fixes this issue.