### PR TITLE
fix: update to bacon-qr-code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "bacon/bacon-qr-code": "^2.0",
+        "bacon/bacon-qr-code": "^3.0",
         "filament/filament": "^3.0.9",
         "illuminate/contracts": "^10.0|^11.0",
         "pragmarx/google2fa": "^7.0|^8.0",


### PR DESCRIPTION
[Up](https://github.com/Bacon/BaconQrCode/releases/tag/v3.0.0)

Breaking change is simply the dropping of older php versions, so this is save as 8.1 and up remains supported as does this packages