### PR TITLE
Support custom polymorphic types in SanctumTokens getTableQuery

### DIFF
--- a/src/Livewire/SanctumTokens.php
+++ b/src/Livewire/SanctumTokens.php
@@ -37,7 +37,7 @@ class SanctumTokens extends MyProfileComponent implements Tables\Contracts\HasTa
 
         return app(Sanctum::$personalAccessTokenModel)->where([
             ['tokenable_id', '=', $auth->id()],
-            ['tokenable_type', '=', get_class($auth->user())],
+            ['tokenable_type', '=', $auth->user()->getMorphClass()],
         ]);
     }
 


### PR DESCRIPTION
The current way (`get_class($auth->user())`) of resolving tokenable_type from auth user doesn't work when using [custom polymorphic types](https://laravel.com/docs/11.x/eloquent-relationships#custom-polymorphic-types).

The `$auth->user()->getMorphClass()` call gives the same result as current implementation when there is no morphMap defined and gives the morphMap key when it's defined.

Tested manually with:

- laravel/framework v11.4.0
- filament/filament v3.2.69.