### PR TITLE
Destroy a recovery code when used – fixes #284

### DIFF
--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -130,6 +130,11 @@ class TwoFactorPage extends SimplePage
             return null;
         }
 
+        // If using a recovery code, unset it so it can only be used once
+        if ($this->usingRecoveryCode) {
+            filament('filament-breezy')->auth()->user()->destroyRecoveryCode($this->code);
+        }
+
         // If it makes it to the bottom, we're going to set the session var and send them to the dashboard.
         filament('filament-breezy')->auth()->user()->setTwoFactorSession();
 

--- a/src/Traits/TwoFactorAuthenticatable.php
+++ b/src/Traits/TwoFactorAuthenticatable.php
@@ -99,6 +99,15 @@ trait TwoFactorAuthenticatable
         })->all()));
     }
 
+    public function destroyRecoveryCode(string $recoveryCode): void
+    {
+        $unusedCodes = array_filter($this->two_factor_recovery_codes ?? [], fn ($code) => $code !== $recoveryCode);
+
+        $this->breezy_session->forceFill([
+            'two_factor_recovery_codes' => $unusedCodes ? encrypt(json_encode($unusedCodes)) : null,
+        ])->save();
+    }
+
     public function getTwoFactorQrCodeUrl()
     {
         return filament('filament-breezy')->getQrCodeUrl(


### PR DESCRIPTION
Fixes #284 

When a recovery code is used, it should be discarded so that it cannot be used again.

This PR will destroy a recovery code when used by filtering it out of the existing set of codes and updating the record.