### PR TITLE
Allow User to back out of 2FA

### DIFF
--- a/src/Pages/TwoFactorPage.php
+++ b/src/Pages/TwoFactorPage.php
@@ -61,7 +61,16 @@ class TwoFactorPage extends SimplePage
                     </x-filament::link>')))
                 ->required()
                 ->extraInputAttributes(['class' => 'text-center', 'autocomplete' => $this->usingRecoveryCode ? 'off' : 'one-time-code'])
-                ->autofocus(),
+                ->autofocus()
+                ->suffixAction(
+                    FormAction::make('cancel')
+                        ->ToolTip(__('filament-breezy::default.cancel'))
+                        ->icon('heroicon-o-x-circle')
+                        ->action(function () {
+                            Filament::auth()->logout();
+                            $this->mount();
+                        })
+                ),
         ];
     }
 


### PR DESCRIPTION
The current path means once a user has entered in their username\password, they are presented with the 2FA code screen.

If the user doesn't have their 2FA information, they are effectively stuck on this screen until the auth times out.

This is undesirable, especially if the login screen has been customised to include help functions etc, or the user has more than one account, and has confused which login to use.

Added discreet cancel option, which sends user back to front login screen.