### PR TITLE
Allow User Menu Link Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Enable the My Profile page with configuration options.
 BreezyCore::make()
     ->myProfile(
         shouldRegisterUserMenu: true, // Sets the 'account' link in the panel User Menu (default = true)
+        userMenuLabel: 'My Profile', // Customizes the 'account' link label in the panel User Menu (default = null)
         shouldRegisterNavigation: false, // Adds a main navigation item for the My Profile page (default = false)
         navigationGroup: 'Settings', // Sets the navigation group for the My Profile page (default = null)
         hasAvatars: false, // Enables the avatar upload form component (default = false)

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -125,12 +125,12 @@ class BreezyCore implements Plugin
                     $tenantId = request()->route()->parameter('tenant');
                     if ($tenantId && $tenant = app($panel->getTenantModel())::where($panel->getTenantSlugAttribute() ?? 'id', $tenantId)->first()) {
                         $panel->userMenuItems([
-                            'account' => MenuItem::make()->url($this->getMyProfilePageClass()::getUrl(panel: $panel->getId(), tenant: $tenant)),
+                            'account' => MenuItem::make()->url($this->getMyProfilePageClass()::getUrl(panel: $panel->getId(), tenant: $tenant))->label($this->myProfile['userMenuLabel']),
                         ]);
                     }
                 } else {
                     $panel->userMenuItems([
-                        'account' => MenuItem::make()->url($this->getMyProfilePageClass()::getUrl()),
+                        'account' => MenuItem::make()->url($this->getMyProfilePageClass()::getUrl())->label($this->myProfile['userMenuLabel']),
                     ]);
                 }
             }
@@ -147,7 +147,7 @@ class BreezyCore implements Plugin
         return Filament::getCurrentPanel();
     }
 
-    public function myProfile(bool $condition = true, bool $shouldRegisterUserMenu = true, bool $shouldRegisterNavigation = false, bool $hasAvatars = false, string $slug = 'my-profile', ?string $navigationGroup = null)
+    public function myProfile(bool $condition = true, bool $shouldRegisterUserMenu = true, bool $shouldRegisterNavigation = false, bool $hasAvatars = false, string $slug = 'my-profile', ?string $navigationGroup = null, ?string $userMenuLabel = null)
     {
         $this->myProfile = get_defined_vars();
 


### PR DESCRIPTION
This PR adds a setting to the `myProfile` method for `userMenuLabel`, which allows customization of the user menu label, like this:

```php
BreezyCore::make()
    ->myProfile(
        shouldRegisterUserMenu: true, // Sets the 'account' link in the panel User Menu (default = true)
        userMenuLabel: 'My Profile', // Customizes the 'account' link label in the panel User Menu (default = null)
    )

```