### PR TITLE
Accept a closure for forcing 2fa and excluding components

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -249,7 +249,7 @@ class BreezyCore implements Plugin
         return $this->{$key}['navigationGroup'] ?? null;
     }
 
-    public function enableTwoFactorAuthentication(bool $condition = true, bool $force = false, string|Closure|array|null $action = TwoFactorPage::class)
+    public function enableTwoFactorAuthentication(bool $condition = true, bool|Closure $force = false, string|Closure|array|null $action = TwoFactorPage::class)
     {
         $this->twoFactorAuthentication = $condition;
         $this->forceTwoFactorAuthentication = $force;
@@ -260,7 +260,7 @@ class BreezyCore implements Plugin
 
     public function getForceTwoFactorAuthentication(): bool
     {
-        return $this->forceTwoFactorAuthentication;
+        return $this->evaluate($this->forceTwoFactorAuthentication);
     }
 
     public function getTwoFactorRouteAction(): string|Closure|array|null
@@ -319,11 +319,13 @@ class BreezyCore implements Plugin
 
     public function shouldForceTwoFactor(): bool
     {
+        $forceTwoFactor = $this->getForceTwoFactorAuthentication();
+        
         if ($this->getCurrentPanel()->isEmailVerificationRequired()) {
-            return $this->forceTwoFactorAuthentication && ! $this->auth()->user()?->hasConfirmedTwoFactor() && $this->auth()->user()?->hasVerifiedEmail();
+            return $forceTwoFactor && ! $this->auth()->user()?->hasConfirmedTwoFactor() && $this->auth()->user()?->hasVerifiedEmail();
         }
 
-        return $this->forceTwoFactorAuthentication && ! $this->auth()->user()?->hasConfirmedTwoFactor();
+        return $forceTwoFactor && ! $this->auth()->user()?->hasConfirmedTwoFactor();
     }
 
     public function enableSanctumTokens(bool $condition = true, ?array $permissions = null)

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -189,19 +189,23 @@ class BreezyCore implements Plugin
         ]);
     }
 
-    public function withoutMyProfileComponents(array $components)
+    public function withoutMyProfileComponents(array|Closure $components)
     {
-        $this->ignoredMyProfileComponents = $components;
+        $this->ignoredMyProfileComponents = is_array($components) ? $components : $this->evaluate($components);
 
         return $this;
     }
 
     public function myProfileComponents(array $components)
     {
+        $ignoredComponents = is_array($this->ignoredMyProfileComponents) 
+            ? $this->ignoredMyProfileComponents 
+            : [];
+
         $this->registeredMyProfileComponents = Arr::except([
             ...$components,
             ...$this->registeredMyProfileComponents,
-        ], $this->ignoredMyProfileComponents);
+        ], $ignoredComponents);
 
         return $this;
     }


### PR DESCRIPTION
This way you can use auth()->user() or other things that are not available at boot time in the service provider.
For example I am hiding the password change component for SSO users and am only forcing 2fa for email and password, not for SSO users.