### PR TITLE
Fixing Bug: BreezyCore::getForceTwoFactorAuthentication(): Return value must be of type bool, null returned

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -273,7 +273,7 @@ class BreezyCore implements Plugin
         return $this;
     }
 
-    public function getForceTwoFactorAuthentication(): bool
+    public function getForceTwoFactorAuthentication(): ?bool
     {
         return $this->evaluate($this->forceTwoFactorAuthentication);
     }


### PR DESCRIPTION
Fixing Issue #412 

It seems to be happening since the closures are now allowed in the `enableTwoFactorAuthentication` method for the `$force` param, it causes `getForceTwoFactorAuthentication` to error out if the `$this->forceTwoFactorAuthentication` = `null` instead of a boolean.

This change allows for nullable boolean