### PR TITLE
Adjust tailwind styling on sanctum plain token display

### DIFF
--- a/resources/views/livewire/sanctum-tokens.blade.php
+++ b/resources/views/livewire/sanctum-tokens.blade.php
@@ -1,6 +1,6 @@
 <x-filament-breezy::grid-section md=2 :title="__('filament-breezy::default.profile.sanctum.title')" :description="__('filament-breezy::default.profile.sanctum.description')">
         @if($plainTextToken)
-            <div class="space-y-2 bg-warning-500">
+            <div class="space-y-2 bg-warning-500 p-4 rounded">
                 <p class="text-sm">{{ __('filament-breezy::default.profile.sanctum.create.message') }}</p>
                 <input type="text" disabled @class(['w-full py-1 px-3 rounded-lg bg-gray-100 border-gray-200 dark:bg-gray-700 dark:border-gray-500']) name="plain_text_token" value="{{$plainTextToken}}" />
                 <div class="flex items-center justify-between">


### PR DESCRIPTION
When generating a sanctum token, the plain token display needs some padding and I added the tailwind rounded class for styling as well.