### PR TITLE
Feature: ability to change 2FA middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ BreezyCore::make()
     ->enableTwoFactorAuthentication(
         force: false, // force the user to enable 2FA before they can use the application (default = false)
         action: CustomTwoFactorPage::class // optionally, use a custom 2FA page
+        authMiddleware: MustTwoFactor::class // optionally, customize 2FA aith middleware or disable it to register manually by setting false
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ BreezyCore::make()
     ->enableTwoFactorAuthentication(
         force: false, // force the user to enable 2FA before they can use the application (default = false)
         action: CustomTwoFactorPage::class // optionally, use a custom 2FA page
-        authMiddleware: MustTwoFactor::class // optionally, customize 2FA aith middleware or disable it to register manually by setting false
+        authMiddleware: MustTwoFactor::class // optionally, customize 2FA auth middleware or disable it to register manually by setting false
     )
 ```
 

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -269,7 +269,7 @@ class BreezyCore implements Plugin
         return $this->{$key}['navigationGroup'] ?? null;
     }
 
-    public function enableTwoFactorAuthentication(bool $condition = true, bool|Closure $force = false, string|Closure|array|null $action = TwoFactorPage::class,  string|false $authMiddleware = MustTwoFactor::class)
+    public function enableTwoFactorAuthentication(bool $condition = true, bool|Closure $force = false, string|Closure|array|null $action = TwoFactorPage::class, string|false $authMiddleware = MustTwoFactor::class)
     {
         $this->twoFactorAuthentication = $condition;
         $this->forceTwoFactorAuthentication = $force;

--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -41,6 +41,8 @@ class BreezyCore implements Plugin
 
     protected $twoFactorAuthentication;
 
+    protected $twoFactorAuthenticationMiddleware = MustTwoFactor::class;
+
     protected $forceTwoFactorAuthentication;
 
     protected $twoFactorRouteAction;
@@ -81,7 +83,10 @@ class BreezyCore implements Plugin
             ->pages($this->preparePages());
         // If TwoFactor is enabled, register the middleware.
         if ($this->twoFactorAuthentication) {
-            $panel->authMiddleware([MustTwoFactor::class]);
+            if ($this->twoFactorAuthenticationMiddleware) {
+                $panel->authMiddleware([$this->twoFactorAuthenticationMiddleware]);
+            }
+
             Livewire::component('two-factor-page', Pages\TwoFactorPage::class);
         }
     }
@@ -264,11 +269,12 @@ class BreezyCore implements Plugin
         return $this->{$key}['navigationGroup'] ?? null;
     }
 
-    public function enableTwoFactorAuthentication(bool $condition = true, bool|Closure $force = false, string|Closure|array|null $action = TwoFactorPage::class)
+    public function enableTwoFactorAuthentication(bool $condition = true, bool|Closure $force = false, string|Closure|array|null $action = TwoFactorPage::class,  string|false $authMiddleware = MustTwoFactor::class)
     {
         $this->twoFactorAuthentication = $condition;
         $this->forceTwoFactorAuthentication = $force;
         $this->twoFactorRouteAction = $action;
+        $this->twoFactorAuthenticationMiddleware = $authMiddleware;
 
         return $this;
     }


### PR DESCRIPTION
PR introduces new optional parameter to `enableTwoFactorAuthentication` named `authMiddleware`.

```php
->enableTwoFactorAuthentication(
     force: false, // force the user to enable 2FA before they can use the application (default = false)
     authMiddleware: CustomTwoFactor::class // optionally, customize 2FA auth middleware or disable it to register manually by setting false
)
```

Using this option users can extend middleware to e.g. disable 2FA when impersonating:

```php
class CustomTwoFactor
{
    /**
     * Handle an incoming request.
     *
     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
     */
    public function handle(Request $request, Closure $next): Response
    {
        if ($request->user()->isImpersonated()) {
            return $next($request);
        }

        return app(MustTwoFactor::class)->handle($request, function ($request) use ($next) {
            return $next($request);
        });
    }
}
```