### PR TITLE
Introduce deferred initialization of sanctumPermissions

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -349,7 +349,7 @@ class BreezyCore implements Plugin
         return $forceTwoFactor && ! $this->auth()->user()?->hasConfirmedTwoFactor();
     }
 
-    public function enableSanctumTokens(bool $condition = true, ?array $permissions = null)
+    public function enableSanctumTokens(bool $condition = true, null|array|Closure $permissions = null)
     {
         $this->sanctumTokens = $condition;
         if (! is_null($permissions)) {
@@ -361,7 +361,7 @@ class BreezyCore implements Plugin
 
     public function getSanctumPermissions(): array
     {
-        return collect($this->sanctumPermissions)->mapWithKeys(function ($item, $key) {
+        return collect($this->evaluate($this->sanctumPermissions))->mapWithKeys(function ($item, $key) {
             $key = is_string($key) ? $key : strtolower($item);
 
             return [$key => $item];


### PR DESCRIPTION
# Deferring Sanctum Token Permissions Initialization

## Feature Overview

This enhancement allows you to defer the initialization of Sanctum token permissions until they are actually needed in the user profile section. This is particularly valuable when permission sets depend on dynamic application entities or runtime context.

## Use Case

This feature is especially useful when your token permissions are based on entities that may not be available during application boot, such as:
- Tenant-specific data in multi-tenant applications
- User-specific permissions based on their role or context
- Dynamic permissions based on related entities (e.g., projects within an organization)

## Implementation

Instead of providing a static array of permissions to the `enableSanctumTokens()` method, you can now pass a Closure that returns the permissions array:

```php
BreezyCore::make()
    ->enableSanctumTokens(
        permissions: function (): array {
            $permissions = [];

            /** @var Organization $organization */
            $organization = Filament::getTenant();

            foreach ($organization->projects as $project) {
                $permissions['projects.'.$project->id.'.read'] = 'Read: '.$project->name;
            }

            return $permissions;
        }
    ),
