### PR TITLE
fix: use panel-defined slugAttribute instead of default 'tenant'

### DIFF
--- a/src/BreezyCore.php
+++ b/src/BreezyCore.php
@@ -126,7 +126,7 @@ class BreezyCore implements Plugin
 
             if ($this->myProfile['shouldRegisterUserMenu']) {
                 if ($panel->hasTenancy()) {
-                    $tenantId = request()->route()->parameter('tenant');
+                    $tenantId = request()->route()->parameter($panel->getTenantSlugAttribute() ?? 'tenant');
                     if ($tenantId && $tenant = app($panel->getTenantModel())::where($panel->getTenantSlugAttribute() ?? 'id', $tenantId)->first()) {
                         $panel->userMenuItems([
                             'account' => MenuItem::make()->url($this->getMyProfilePageClass()::getUrl(panel: $panel->getId(), tenant: $tenant))->label($this->myProfile['userMenuLabel']),


### PR DESCRIPTION
## 🛠️ What this PR does

This PR updates the parameter to use the `slugAttribute` defined in the Filament panel's multitenancy configuration, instead of hardcoding the `'tenant'` string.

---

## 🐞 Problem

Previously, the code assumed the tenant slug would always be `'tenant'`, which caused errors when a custom `slugAttribute` (e.g., `'account'`, `'organization'`, etc.) was used in the panel definition.

---

## ✅ Fix

This change retrieves the slug dynamically from the panel's `slugAttribute`, allowing custom slugs to work correctly without throwing exceptions.

---

## 🔄 Example

If a panel defines:

```php
->slugAttribute('organization')
