### PR TITLE
Allow Htmlable as a type for titles, headings and subheadings of the MyProfilePage

### DIFF
--- a/src/Pages/MyProfilePage.php
+++ b/src/Pages/MyProfilePage.php
@@ -3,6 +3,7 @@
 namespace Jeffgreco13\FilamentBreezy\Pages;
 
 use Filament\Pages\Page;
+use Illuminate\Contracts\Support\Htmlable;
 
 class MyProfilePage extends Page
 {
@@ -10,17 +11,17 @@ class MyProfilePage extends Page
 
     protected static string $view = 'filament-breezy::filament.pages.my-profile';
 
-    public function getTitle(): string
+    public function getTitle(): string | Htmlable
     {
         return __('filament-breezy::default.profile.my_profile');
     }
 
-    public function getHeading(): string
+    public function getHeading(): string | Htmlable
     {
         return __('filament-breezy::default.profile.my_profile');
     }
 
-    public function getSubheading(): ?string
+    public function getSubheading(): string | Htmlable | null
     {
         return __('filament-breezy::default.profile.subheading') ?? null;
     }


### PR DESCRIPTION
Aloha, thank you for creating Breezy, it is such a helpful package! Really appreciate the work you put into this.

This PR is just a small one to allow easier customization of the profile page. At the moment, one cannot extend the MyProfilePage class to change just the subheading in case HTML is needed there:

```php
<?php

namespace App\Filament\Auth;

use Filament\Pages\Page;
use Illuminate\Contracts\Support\Htmlable;
use Illuminate\Support\HtmlString;
use Jeffgreco13\FilamentBreezy\Pages\MyProfilePage;

class CustomProfilePage extends MyProfilePage
{
    public function getSubheading(): Htmlable // <-- does not work, declaration is not compatible with MyProfilePage::getSubHeading()
    {
        return new HtmlString('<strong>My custom subheading with <em>HTML</em></strong>');
    }
```

The change allows Htmlable as a return type like in the BasePage class.