### PR TITLE
Refactor personal info

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,16 @@ class CustomPersonalInfo extends PersonalInfo
 {
     public ?array $only = ['custom_name_field', 'custom_email_field'];
 
+    // You can override the default components by returning an array of components.
+    protected function getProfileFormComponents(): array
+    {
+        return [
+            $this->getNameComponent(),
+            $this->getEmailComponent(),
+            $this->getCustomComponent(),
+        ];
+    }
+
     protected function getNameComponent(): Forms\Components\TextInput
     {
         return Forms\Components\TextInput::make('custom_name_field')

--- a/src/Livewire/PersonalInfo.php
+++ b/src/Livewire/PersonalInfo.php
@@ -38,14 +38,20 @@ class PersonalInfo extends MyProfileComponent
 
     protected function getProfileFormSchema(): array
     {
-        $groupFields = Forms\Components\Group::make([
-            $this->getNameComponent(),
-            $this->getEmailComponent(),
-        ])->columnSpan(2);
+        $groupFields = Forms\Components\Group::make($this->getProfileFormComponents())
+            ->columnSpan(2);
 
         return ($this->hasAvatars)
             ? [filament('filament-breezy')->getAvatarUploadComponent(), $groupFields]
             : [$groupFields];
+    }
+
+    protected function getProfileFormComponents(): array
+    {
+        return [
+            $this->getNameComponent(),
+            $this->getEmailComponent(),
+        ];
     }
 
     protected function getNameComponent(): Forms\Components\TextInput


### PR DESCRIPTION
Hi @jeffgreco13,

This PR refactors the personal info component to improve its extensibility and maintainability. 
For example, the developer wants to add custom inputs for form and with `getProfileFormComponents` it's easier to do it.