### PR TITLE
Fix: Missing Italian translation for 2FA

### DIFF
--- a/resources/lang/it/default.php
+++ b/resources/lang/it/default.php
@@ -49,6 +49,7 @@ return [
                 'disable' => 'Disabilita',
                 'confirm_finish' => 'Conferma & procedi',
                 'cancel_setup' => 'Annulla il setup',
+                'confirm' => 'Conferma',
             ],
             'setup_key' => 'Chiave di Setup',
             'must_enable' => 'Per utilizzare questa applicazione devi abilitare la 2FA.',


### PR DESCRIPTION
I know, it's a very small PR but I've added the missing "confirm" translation key to the Italian language file (`it/default.php`) for the two-factor authentication actions. Best