### PR TITLE
Change `login` field label to `Verifiëren` for dutch translations

### DIFF
--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -119,7 +119,7 @@ return [
     'fields' => [
         'avatar' => 'Profielfoto',
         'email' => 'E-mailadres',
-        'login' => 'Gebruikersnaam',
+        'login' => 'Verifiëren',
         'name' => 'Naam',
         'password' => 'Wachtwoord',
         'password_confirm' => 'Wachtwoord bevestigen',


### PR DESCRIPTION
In the dutch translations file, the `fields.login` entry returns `Gebruikersnaam`. This is as the Verify button for the 2FA code. 

Doesn't make any sense. I've changed it to 'Verifiëren'. 